### PR TITLE
Streamline timers

### DIFF
--- a/include/aitemtimer.h
+++ b/include/aitemtimer.h
@@ -10,7 +10,6 @@
 class AItemTimer : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QTimer *timeLapse READ timelapse NOTIFY timeLapseChanged)
     Q_PROPERTY(QString elapsedTime READ elapsedTime NOTIFY elapsedTimeChanged) // Add this line
     QML_ELEMENT
 public:
@@ -32,7 +31,7 @@ private slots:
 
 private:
     QTimer *m_timelapse;
-    QElapsedTimer m_elapsedTimer;
+    int m_elapsedTime;
 };
 
 #endif // AITEMTIMER_H

--- a/src/aitemtimer.cpp
+++ b/src/aitemtimer.cpp
@@ -1,8 +1,9 @@
 #include "aitemtimer.h"
 
-AItemTimer::AItemTimer(QObject *parent) : QObject{parent}
+AItemTimer::AItemTimer(QObject *parent) : QObject{parent}, m_elapsedTime(0)
 {
     m_timelapse = new QTimer{this};
+    m_timelapse->setInterval(1000);
     connect(m_timelapse, &QTimer::timeout, this, &AItemTimer::onTimerTimeout);
 }
 
@@ -13,27 +14,24 @@ QTimer *AItemTimer::timelapse() const
 
 QString AItemTimer::elapsedTime() const
 {
-    qDebug() << "Elapsed time: " << m_elapsedTimer.elapsed() / 1000 << " seconds";
-    return QString::number(m_elapsedTimer.elapsed() / 1000); // Convert milliseconds to seconds as QString
+    return QString::number(m_elapsedTime);
 }
 
 void AItemTimer::start()
 {
     qDebug() << "Timer Started";
     m_timelapse->start();
-    m_elapsedTimer.start(); // Start the elapsed timer
 }
 
 void AItemTimer::stop()
 {
     m_timelapse->stop();
-    m_elapsedTimer.invalidate(); // Invalidate the elapsed timer
 }
 
 void AItemTimer::onTimerTimeout()
 {
     qDebug() << "on Timer Timeout";
+    qDebug() << "Elapsed time: " << ++m_elapsedTime << " seconds";
 
-    // m_timelapse->stop();
     emit elapsedTimeChanged();
 }


### PR DESCRIPTION
- Use only one single timer instead of two.
- Set the timer to one-second interval to reduce number of events and unnecessary UI redraws.